### PR TITLE
Updated finagle and curator dependency for tests, adds kafka test jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,23 +61,6 @@ $ sbt package
 
 ## Running tests
 
-The tests require Kafka TestUtils which are currently not distributed
-using Maven. The test jar is built directly from Kafka source.
-
-```
-git clone https://github.com/apache/kafka.git
-cd kafka
-git fetch
-git checkout 0.8.1
-./gradlew -PscalaVersion=2.10.4 testJar
-```
-
-Copy the test-jar to the lib dir in the finagle-kafka project.
-
-```
-cp kafka/core/build/libs/kafka_2.10-test-0.8.1.1.jar finagle-kafka/lib/
-```
-
 Tests are run using sbt.
 
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ scalaVersion := "2.10.4"
 net.virtualvoid.sbt.graph.Plugin.graphSettings
 
 libraryDependencies ++= List(
-  "com.twitter" % "finagle-core_2.10" % "6.17.0",
+  "com.twitter" % "finagle-core_2.10" % "6.24.0",
   "org.apache.kafka" % "kafka_2.10" % "0.8.1.1"
     exclude("com.101tec", "zkclient")
     exclude("com.yammer.metrics", "metrics-core")
@@ -23,9 +23,10 @@ libraryDependencies ++= List(
   "org.scalatest" % "scalatest_2.10" % "2.1.7" % "test",
   // dependencies for kafka-test
   "junit" % "junit" % "4.11" % "test",
-  "org.apache.curator" % "curator-test" % "2.4.2" % "test",
+  "org.apache.curator" % "curator-test" % "2.7.1" % "test",
   "com.101tec" % "zkclient" % "0.4" % "test",
-  "com.yammer.metrics" % "metrics-core" % "2.2.0" % "test"
+  "com.yammer.metrics" % "metrics-core" % "2.2.0" % "test",
+  "org.apache.kafka" % "kafka_2.10" % "0.8.1.1" % "test" classifier "test"
 )
 
 publishTo := {

--- a/src/main/scala/okapies/finagle/Kafka.scala
+++ b/src/main/scala/okapies/finagle/Kafka.scala
@@ -4,7 +4,7 @@ import com.twitter.finagle.{Client, Name}
 import com.twitter.finagle.client.{Bridge, DefaultClient}
 import com.twitter.finagle.dispatch.PipeliningDispatcher
 import com.twitter.finagle.netty3.Netty3Transporter
-import com.twitter.finagle.pool.ReusingPool
+import com.twitter.finagle.pool.SingletonPool
 import com.twitter.finagle.stats.StatsReceiver
 
 import okapies.finagle.kafka.protocol.{KafkaBatchClientPipelineFactory, KafkaStreamClientPipelineFactory, Request, Response}
@@ -26,7 +26,7 @@ object KafkaClient extends DefaultClient[Request, Response](
   name = "kafka",
   endpointer =
     Bridge[Request, Response, Request, Response](KafkaTransporter, new PipeliningDispatcher(_)),
-  pool = (sr: StatsReceiver) => new ReusingPool(_, sr)
+  pool = (sr: StatsReceiver) => new SingletonPool(_, sr)
 ) with KafkaRichClient
 
 object Kafka extends Client[Request, Response] with KafkaRichClient {

--- a/src/test/scala/okapies/finagle/kafka/ClientTest.scala
+++ b/src/test/scala/okapies/finagle/kafka/ClientTest.scala
@@ -50,9 +50,6 @@ trait KafkaTest extends BeforeAndAfterAll { suite: Suite =>
     kafkaServer.shutdown()
     Utils.rm(kafkaConfig.getProperty("log.dir"))
     zkClient.close()
-    // Note:
-    // InstanceNotFoundException will be thrown in 'TestingServer' thread
-    // when stopping it. See https://github.com/Netflix/curator/issues/121
     zkServer.stop()
     Utils.rm(zkServer.getTempDirectory)
   }


### PR DESCRIPTION
- Finagle upgrade to version 6.24.0
- Curator upgrade to 2.7.1, resolves issue with exception when shutting down zookeeper in test
- Fetches the kafka-test jar for 0.8.1.1 to avoid building the jar from source