### PR TITLE
Kafka server implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ project/plugins/project/
 *.iml
 *.ipr
 *.iws
+
+# vim
+*.swp

--- a/src/main/scala/okapies/finagle/Kafka.scala
+++ b/src/main/scala/okapies/finagle/Kafka.scala
@@ -1,13 +1,17 @@
 package okapies.finagle
 
-import com.twitter.finagle.{Client, Name}
+import com.twitter.util.{Future, Promise}
+import com.twitter.finagle.{Client, Name, Server, Service, ServiceFactory}
 import com.twitter.finagle.client.{Bridge, DefaultClient}
-import com.twitter.finagle.dispatch.PipeliningDispatcher
-import com.twitter.finagle.netty3.Netty3Transporter
+import com.twitter.finagle.server.DefaultServer
+import com.twitter.finagle.dispatch.{PipeliningDispatcher, GenSerialServerDispatcher}
+import com.twitter.finagle.netty3.{Netty3Transporter, Netty3Listener}
 import com.twitter.finagle.pool.SingletonPool
+import com.twitter.finagle.transport.Transport
 import com.twitter.finagle.stats.StatsReceiver
+import java.net.SocketAddress
 
-import okapies.finagle.kafka.protocol.{KafkaBatchClientPipelineFactory, KafkaStreamClientPipelineFactory, Request, Response}
+import okapies.finagle.kafka.protocol._
 
 trait KafkaRichClient { self: Client[Request, Response] =>
 
@@ -29,8 +33,48 @@ object KafkaClient extends DefaultClient[Request, Response](
   pool = (sr: StatsReceiver) => new SingletonPool(_, sr)
 ) with KafkaRichClient
 
-object Kafka extends Client[Request, Response] with KafkaRichClient {
+class KafkaServerDispatcher(
+  trans: Transport[Response, Request],
+  service: Service[Request, Response])
+extends GenSerialServerDispatcher[Request, Response, Response, Request](trans) {
+
+  trans.onClose ensure {
+    service.close()
+  }
+
+  protected def dispatch(msg: Request, eos: Promise[Unit]) = msg match {
+    case req: Request =>
+      service(req) ensure eos.setDone()
+    case failure =>
+      eos.setDone
+      Future.exception(new IllegalArgumentException(s"Invalid message $failure"))
+  }
+
+  protected def handle(resp: Response) = {
+    trans.write(resp)
+  }
+}
+
+
+object Kafka
+extends Client[Request, Response]
+with KafkaRichClient
+with Server[Request, Response] {
 
   def newClient(dest: Name, label: String) = KafkaClient.newClient(dest, label)
 
+  class Server() extends DefaultServer[Request, Response, Response, Request](
+    "kafka-server",
+    new Netty3Listener(
+      "kafka-server-listener",
+      new KafkaServerPipelineFactory
+    ),
+    new KafkaServerDispatcher(_, _)
+  )
+
+  private val server = new Server()
+
+  def serve(addr: SocketAddress, service: ServiceFactory[Request, Response]) =
+    server.serve(addr, service)
 }
+

--- a/src/main/scala/okapies/finagle/Kafka.scala
+++ b/src/main/scala/okapies/finagle/Kafka.scala
@@ -50,8 +50,9 @@ extends GenSerialServerDispatcher[Request, Response, Response, Request](trans) {
       Future.exception(new IllegalArgumentException(s"Invalid message $failure"))
   }
 
-  protected def handle(resp: Response) = {
-    trans.write(resp)
+  protected def handle(resp: Response) = resp match {
+    case r:NilResponse => Future.Unit
+    case anyResp => trans.write(resp)
   }
 }
 

--- a/src/main/scala/okapies/finagle/kafka/protocol/KafkaCodec.scala
+++ b/src/main/scala/okapies/finagle/kafka/protocol/KafkaCodec.scala
@@ -73,6 +73,15 @@ class KafkaServerPipelineFactory extends ChannelPipelineFactory {
   def getPipeline() = {
     val pipeline = Channels.pipeline()
 
+    // decoders (upstream)
+    pipeline.addLast("frameDecoder", new LengthFieldBasedFrameDecoder(Int.MaxValue, 0, 4, 0, 4))
+    // actual request to server
+    pipeline.addLast("requestDecoder", new RequestDecoder())
+
+    // encoders (downstream)
+    pipeline.addLast("frameEncoder", new LengthFieldPrepender(4))
+    pipeline.addLast("responseEncoder", new ResponseEncoder())
+
     pipeline
   }
 }

--- a/src/main/scala/okapies/finagle/kafka/protocol/Response.scala
+++ b/src/main/scala/okapies/finagle/kafka/protocol/Response.scala
@@ -115,6 +115,9 @@ case class ConsumerMetadataResult(
   port: Int           // int32
 )
 
+// NilResponse, used by server to indicate that no response is needed
+case class NilResponse(correlationId:Int) extends Response
+
 /**
  * A message frame for responses.
  */

--- a/src/main/scala/okapies/finagle/kafka/protocol/Spec.scala
+++ b/src/main/scala/okapies/finagle/kafka/protocol/Spec.scala
@@ -172,6 +172,13 @@ private[protocol] object Spec {
       messages.foreach(f)
     }
 
+    @inline
+    def encodeMessageSetWithOffset(messages: Seq[MessageWithOffset])(f: MessageWithOffset => Unit) = {
+      buf.encodeInt32(messages.foldLeft(0)(_ + OffsetLength + MessageSizeLength + _.message.size))
+      messages.foreach(f)
+    }
+
+
     /*
      * Methods for decoding next bytes.
      */

--- a/src/test/scala/okapies/finagle/kafka/ServerTest.scala
+++ b/src/test/scala/okapies/finagle/kafka/ServerTest.scala
@@ -1,0 +1,186 @@
+package okapies.finagle.kafka
+
+import org.scalatest._
+import org.scalatest.matchers._
+import org.jboss.netty.buffer.{ChannelBuffer, ChannelBuffers}
+import com.twitter.concurrent.AsyncQueue
+import com.twitter.util.{Future, Await}
+import com.twitter.finagle.{Service, ListeningServer}
+import com.twitter.finagle.transport.{Transport, QueueTransport}
+
+import okapies.finagle.Kafka
+import protocol._
+
+
+class ServerTest
+extends FlatSpec
+with Matchers {
+  import Await._
+
+  private val addr = ":9993"
+
+  // service that responds corresponding to the request
+  val service = Service.mk[Request, Response] {
+    case req => Future.value(null)
+  }
+
+
+  // tests the server dispatcher
+  "A Kafka Server" should "start and shutdown" in {
+    val server = Kafka.serve(addr, service)
+    result(server.close()) should be(())
+  }
+
+  it should "handle a client connecting and disconnecting" in {
+    val server = Kafka.serve(addr, service)
+
+    val client = Kafka.newRichClient(addr)
+
+    result(client.close()) should be(())
+
+    ready(server.close())
+  }
+}
+
+class ServerRequestResponseTest
+extends FlatSpec
+with Matchers
+with BeforeAndAfterEach {
+  import Await._
+
+  val ClientId = "test-client"
+  val Topic = "test-topic"
+  val Msg = Message.create(ChannelBuffers.EMPTY_BUFFER)
+  val ConsumerGroup = "test-group"
+
+  val broker = Broker(0, "test", 9092)
+
+  val partitionMetadata = PartitionMetadata(
+    KafkaError.NoError,
+    0,
+    leader = Some(broker),
+    replicas = Seq(broker),
+    isr = Seq(broker)
+  )
+
+  val topicMetadata = TopicMetadata(
+    KafkaError.NoError,
+    Topic,
+    Seq(partitionMetadata)
+  )
+
+  val metadataResp = MetadataResponse(0, Seq(broker), Seq(topicMetadata))
+
+  val produceResult = ProduceResult(KafkaError.NoError, 0)
+
+  val produceResp = ProduceResponse(0, Map(Topic -> Map(0 -> produceResult)))
+
+  val offsetResp = OffsetResponse(0, Map(Topic ->
+    Map(0 -> OffsetResult(KafkaError.NoError, Seq(0,1)))))
+
+  val fetchResp = FetchResponse(0, Map(Topic ->
+    Map(0 -> FetchResult(KafkaError.NoError, 0, Seq(MessageWithOffset(0, Msg))))))
+
+  val offsetCommitResp = OffsetCommitResponse(0, Map(Topic ->
+    Map(0 -> OffsetCommitResult(KafkaError.NoError))))
+
+  val offsetFetchResp = OffsetFetchResponse(0, Map(Topic ->
+    Map(0 -> OffsetFetchResult(0, "metadata", KafkaError.NoError))))
+
+  val consumerMetadataResp = ConsumerMetadataResponse(0,
+    ConsumerMetadataResult(KafkaError.NoError, 0, "broker", 9092))
+
+  // service that responds corresponding to the request
+  val service = Service.mk[Request, Response] {
+    case req: MetadataRequest =>
+      Future.value(metadataResp)
+
+    case req: FetchRequest =>
+      Future.value(fetchResp)
+
+    case req: ProduceRequest =>
+      Future.value(produceResp)
+
+    case req: OffsetRequest =>
+      Future.value(offsetResp)
+
+    case req: OffsetCommitRequest =>
+      Future.value(offsetCommitResp)
+
+    case req: OffsetFetchRequest =>
+      Future.value(offsetFetchResp)
+
+    case req: ConsumerMetadataRequest =>
+      Future.value(consumerMetadataResp)
+
+    case req => Future.value(null)
+  }
+
+  var client: Service[Request, Response] = _
+  var server: ListeningServer = _
+  var rand = new scala.util.Random()
+
+  private def newAddr:String = {
+    s":${10000 + rand.nextInt(1000)}"
+  }
+
+  override def beforeEach = {
+    val addr = newAddr
+    server = Kafka.serve(addr, service)
+    client = Kafka.newService(server)
+  }
+
+  override def afterEach = {
+    ready(client.close())
+    result(server.close())
+  }
+
+  "A kafka server receiving requests" should
+    "respond to produce requests" in {
+      val resp = result(client(ProduceRequest(0, ClientId, RequiredAcks(0), 1000,
+        Map(Topic -> Map(0 -> Seq(Msg))))))
+
+      resp should be(produceResp)
+    }
+ 
+    it should "respond to fetch requests" in {
+      val resp = result(client(FetchRequest(0, ClientId, 0, 0, 0,
+        Map(Topic -> Map(0 -> FetchOffset(0, 1))))))
+
+      resp should be(fetchResp)
+    }
+
+    it should "respond to offset requests" in {
+      val resp = result(client(OffsetRequest(0, ClientId, 0,
+        Map(Topic -> Map(0 -> OffsetFilter(0, 1))))))
+
+      resp should be(offsetResp)
+    }
+
+    it should "respond to metadata requests" in {
+      val resp = result(client(MetadataRequest(0, ClientId, Seq(Topic))))
+
+      resp should be(metadataResp)
+    }
+
+    it should "respond to offset commit requests (v1)" in {
+      val resp = result(client(OffsetCommitRequest(0, ClientId, ConsumerGroup,
+        Map(Topic -> Map(0 -> CommitOffset(0, "metadata"))))))
+
+      resp should be(offsetCommitResp)
+    }
+
+    it should "respond to offset fetch requests" in {
+      val resp = result(client(OffsetFetchRequest(0, ClientId, ConsumerGroup,
+        Map(Topic -> Seq(0)))))
+
+      resp should be(offsetFetchResp)
+    }
+
+    it should "respond to consumer metadata requests" in {
+      val resp = result(client(ConsumerMetadataRequest(0, ClientId, ConsumerGroup)))
+
+      resp should be(consumerMetadataResp)
+    }
+
+}


### PR DESCRIPTION
This PR implements the kafka server request/response protocol. It makes it possible to create, for example, a finagle-based kafka broker or proxy.

- Implements request decoding and response encoding
- Creates server wiring with a netty pipeline and a finagle DefaultServer
- High-level tests for each request and response
- Only implements v0 of CommitOffsetRequests