### PR TITLE
Migration from finagle netty3 to finagle netty4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,8 +13,8 @@ scalaVersion := "2.11.12"
 crossScalaVersions := Seq("2.11.12")
 
 libraryDependencies ++= List(
-  "com.twitter" %% "finagle-core" % "19.3.0",
-  "com.twitter" %% "finagle-netty4" % "19.3.0",
+  "com.twitter" %% "finagle-core" % "19.5.1",
+  "com.twitter" %% "finagle-netty4" % "19.5.1",
   "org.apache.kafka" %% "kafka" % "0.8.2.1"
     exclude("com.101tec", "zkclient")
     exclude("com.yammer.metrics", "metrics-core")

--- a/build.sbt
+++ b/build.sbt
@@ -13,8 +13,8 @@ scalaVersion := "2.11.12"
 crossScalaVersions := Seq("2.11.12")
 
 libraryDependencies ++= List(
-  "com.twitter" %% "finagle-core" % "19.1.0",
-  "com.twitter" %% "finagle-netty3" % "19.1.0",
+  "com.twitter" %% "finagle-core" % "19.3.0",
+  "com.twitter" %% "finagle-netty4" % "19.3.0",
   "org.apache.kafka" %% "kafka" % "0.8.2.1"
     exclude("com.101tec", "zkclient")
     exclude("com.yammer.metrics", "metrics-core")

--- a/src/main/scala/okapies/finagle/kafka/protocol/KafkaCodec.scala
+++ b/src/main/scala/okapies/finagle/kafka/protocol/KafkaCodec.scala
@@ -2,21 +2,11 @@ package okapies.finagle.kafka.protocol
 
 import scala.collection._
 
-import org.jboss.netty.channel.{ChannelPipelineFactory, Channels}
-import org.jboss.netty.handler.codec.frame.{LengthFieldPrepender, LengthFieldBasedFrameDecoder}
+import io.netty.channel.ChannelPipeline
+import io.netty.handler.codec.{LengthFieldPrepender, LengthFieldBasedFrameDecoder}
 
 import com.twitter.finagle._
 import com.twitter.finagle.stats.{NullStatsReceiver, StatsReceiver}
-
-object KafkaCodec {
-
-  def apply() = new KafkaCodecFactory()
-
-  def apply(stats: StatsReceiver = NullStatsReceiver) = new KafkaCodecFactory(stats)
-
-  def get() = apply()
-
-}
 
 trait RequestCorrelator extends (Int => Option[Short])
 
@@ -69,11 +59,18 @@ class CorrelationIdRequestCorrelator extends RequestCorrelator with RequestLogge
 
 }
 
-class KafkaServerPipelineFactory extends ChannelPipelineFactory {
-  def getPipeline() = {
-    val pipeline = Channels.pipeline()
+object KafkaServerPipelineFactory extends (ChannelPipeline => Unit) {
 
+  def apply(pipeline: ChannelPipeline) = {
     // decoders (upstream)
+    
+    /**
+     * Kafka request protocol
+     * {{{
+     * RequestOrResponse => Size (RequestMessage | ResponseMessage)
+     *    Size => int32
+     * }}}
+     */
     pipeline.addLast("frameDecoder", new LengthFieldBasedFrameDecoder(Int.MaxValue, 0, 4, 0, 4))
     // actual request to server
     pipeline.addLast("requestDecoder", new RequestDecoder())
@@ -81,16 +78,12 @@ class KafkaServerPipelineFactory extends ChannelPipelineFactory {
     // encoders (downstream)
     pipeline.addLast("frameEncoder", new LengthFieldPrepender(4))
     pipeline.addLast("responseEncoder", new ResponseEncoder())
-
-    pipeline
   }
 }
 
-object KafkaBatchClientPipelineFactory extends ChannelPipelineFactory {
+object KafkaBatchClientPipelineFactory extends (ChannelPipeline => Unit) {
 
-  def getPipeline() = {
-    val pipeline = Channels.pipeline()
-
+  def apply(pipeline: ChannelPipeline) = {
     val correlator = new QueueRequestCorrelator
 
     // encoders (downstream)
@@ -100,17 +93,13 @@ object KafkaBatchClientPipelineFactory extends ChannelPipelineFactory {
     // decoders (upstream)
     pipeline.addLast("frameDecoder", new LengthFieldBasedFrameDecoder(Int.MaxValue, 0, 4, 0, 4))
     pipeline.addLast("responseDecoder", new BatchResponseDecoder(correlator))
-
-    pipeline
   }
 
 }
 
-object KafkaStreamClientPipelineFactory extends ChannelPipelineFactory {
+object KafkaStreamClientPipelineFactory extends (ChannelPipeline => Unit) {
 
-  def getPipeline() = {
-    val pipeline = Channels.pipeline()
-
+  def apply(pipeline: ChannelPipeline) = {
     val correlator = new QueueRequestCorrelator
 
     // encoders (downstream)
@@ -120,36 +109,7 @@ object KafkaStreamClientPipelineFactory extends ChannelPipelineFactory {
     // decoders (upstream)
     pipeline.addLast("frameDecoder", new StreamFrameDecoder(correlator, 8192))
     pipeline.addLast("responseDecoder", new StreamResponseDecoder)
-
-    pipeline
   }
-
-}
-
-class KafkaCodecFactory(stats: StatsReceiver) extends CodecFactory[Request, Response] {
-
-  def this() = this(NullStatsReceiver)
-
-  def server: ServerCodecConfig => Codec[Request, Response] =
-    Function.const {
-      new Codec[Request, Response] {
-        def pipelineFactory = new KafkaServerPipelineFactory
-      }
-    }
-
-  def client: ClientCodecConfig => Codec[Request, Response] =
-    Function.const {
-      new Codec[Request, Response] {
-        def pipelineFactory = KafkaStreamClientPipelineFactory
-
-        override def prepareConnFactory(
-          underlying: ServiceFactory[Request, Response],
-          params: Stack.Params
-        ): ServiceFactory[Request, Response] = {
-          new KafkaTracingFilter() andThen new KafkaLoggingFilter(stats) andThen underlying
-        }
-      }
-    }
 
 }
 

--- a/src/main/scala/okapies/finagle/kafka/protocol/KafkaCodec.scala
+++ b/src/main/scala/okapies/finagle/kafka/protocol/KafkaCodec.scala
@@ -113,18 +113,3 @@ object KafkaStreamClientPipelineFactory extends (ChannelPipeline => Unit) {
 
 }
 
-private class KafkaTracingFilter extends SimpleFilter[Request, Response] {
-
-  override def apply(request: Request, service: Service[Request, Response]) = service(request)
-
-}
-
-private class KafkaLoggingFilter(stats: StatsReceiver)
-  extends SimpleFilter[Request, Response] {
-
-  private[this] val error = stats.scope("error")
-  private[this] val succ  = stats.scope("success")
-
-  override def apply(request: Request, service: Service[Request, Response]) = service(request)
-
-}

--- a/src/main/scala/okapies/finagle/kafka/protocol/Response.scala
+++ b/src/main/scala/okapies/finagle/kafka/protocol/Response.scala
@@ -1,6 +1,6 @@
 package okapies.finagle.kafka.protocol
 
-import org.jboss.netty.buffer.ChannelBuffer
+import io.netty.buffer.ByteBuf
 
 import com.twitter.concurrent.Offer
 import com.twitter.util.Future
@@ -126,7 +126,7 @@ sealed trait ResponseFrame
 case class BufferResponseFrame(
   apiKey: Short,
   correlationId: Int,
-  frame: ChannelBuffer
+  frame: ByteBuf
 ) extends ResponseFrame
 
 case class FetchResponseFrame(

--- a/src/main/scala/okapies/finagle/kafka/protocol/Spec.scala
+++ b/src/main/scala/okapies/finagle/kafka/protocol/Spec.scala
@@ -5,7 +5,7 @@ import java.nio.charset.Charset
 import scala.annotation.tailrec
 import scala.collection.mutable.ArrayBuffer
 
-import org.jboss.netty.buffer.ChannelBuffer
+import io.netty.buffer.ByteBuf
 
 import _root_.kafka.common.KafkaException
 import _root_.kafka.message.InvalidMessageException
@@ -49,34 +49,34 @@ private[protocol] object Spec {
   import scala.language.implicitConversions
 
   /**
-   * The wrapper of ChannelBuffer that provides helper methods for Kafka protocol.
+   * The wrapper of ByteBuf that provides helper methods for Kafka protocol.
    */
-  private[protocol] implicit class KafkaChannelBuffer(val buf: ChannelBuffer) extends AnyVal {
+  private[protocol] implicit class KafkaByteBuf(val buf: ByteBuf) extends AnyVal {
 
     /*
      * Methods for encoding value and writing into buffer.
      */
 
     /**
-     * A simple wrapper for [[org.jboss.netty.buffer.ChannelBuffer#writeByte]].
+     * A simple wrapper for [[org.jboss.netty.buffer.ByteBuf#writeByte]].
      */
     @inline
     def encodeInt8(integer: Int8) = buf.writeByte(integer.asInstanceOf[Int])
 
     /**
-     * A simple wrapper for [[org.jboss.netty.buffer.ChannelBuffer#writeShort]].
+     * A simple wrapper for [[org.jboss.netty.buffer.ByteBuf#writeShort]].
      */
     @inline
     def encodeInt16(integer: Int16) = buf.writeShort(integer.asInstanceOf[Int])
 
     /**
-     * A simple wrapper for [[org.jboss.netty.buffer.ChannelBuffer#writeInt]].
+     * A simple wrapper for [[org.jboss.netty.buffer.ByteBuf#writeInt]].
      */
     @inline
     def encodeInt32(integer: Int32) = buf.writeInt(integer)
 
     /**
-     * A simple wrapper for [[org.jboss.netty.buffer.ChannelBuffer#writeLong]].
+     * A simple wrapper for [[org.jboss.netty.buffer.ByteBuf#writeLong]].
      */
     @inline
     def encodeInt64(integer: Int64) = buf.writeLong(integer)
@@ -86,7 +86,7 @@ private[protocol] object Spec {
      * transferred bytes is (4 + bytes.readableBytes).
      */
     @inline
-    def encodeBytes(bytes: ChannelBuffer) {
+    def encodeBytes(bytes: ByteBuf) {
       if (bytes != null) {
         val n: Int32 = bytes.readableBytes
         buf.encodeInt32(n)          // int32 (length field)
@@ -196,7 +196,7 @@ private[protocol] object Spec {
     def decodeInt64(): Int64 = buf.readLong()
 
     @inline
-    def decodeBytes(): ChannelBuffer = {
+    def decodeBytes(): ByteBuf = {
       val n = buf.decodeInt32() // N => int32
       buf.readBytes(n)          // content
     }
@@ -230,7 +230,7 @@ private[protocol] object Spec {
     @inline
     def decodeMessageSet(): Seq[MessageWithOffset] = {
       @tailrec
-      def decodeMessages(msgSetBuf: ChannelBuffer,
+      def decodeMessages(msgSetBuf: ByteBuf,
                          msgSet: ArrayBuffer[MessageWithOffset]): Seq[MessageWithOffset] = {
         if (msgSetBuf.readableBytes < 12) {    // 12 = length(Offset+MessageSize)
           msgSet

--- a/src/main/scala/okapies/finagle/kafka/protocol/package.scala
+++ b/src/main/scala/okapies/finagle/kafka/protocol/package.scala
@@ -1,6 +1,6 @@
 package okapies.finagle.kafka
 
-import org.jboss.netty.buffer.ChannelBuffers
+import io.netty.buffer.Unpooled
 
 package object protocol {
 
@@ -12,12 +12,12 @@ package object protocol {
   implicit def asRequiredAcks(requiredAcks: Short) = RequiredAcks(requiredAcks)
 
   implicit def asMessage(value: String): Message =
-    Message.create(ChannelBuffers.wrappedBuffer(value.getBytes(Spec.DefaultCharset)))
+    Message.create(Unpooled.wrappedBuffer(value.getBytes(Spec.DefaultCharset)))
 
   implicit def asMessage(entry: (String, String)): Message =
     Message.create(
-      ChannelBuffers.wrappedBuffer(entry._2.getBytes(Spec.DefaultCharset)),
-      Option(ChannelBuffers.wrappedBuffer(entry._1.getBytes(Spec.DefaultCharset))))
+      Unpooled.wrappedBuffer(entry._2.getBytes(Spec.DefaultCharset)),
+      Option(Unpooled.wrappedBuffer(entry._1.getBytes(Spec.DefaultCharset))))
 
   implicit def asKafkaError(code: Short): KafkaError = KafkaError(code)
 

--- a/src/test/scala/okapies/finagle/kafka/ClientTest.scala
+++ b/src/test/scala/okapies/finagle/kafka/ClientTest.scala
@@ -13,7 +13,7 @@ import _root_.kafka.admin.AdminUtils
 import _root_.kafka.utils.{Utils, TestUtils, ZKStringSerializer}
 import _root_.kafka.server.{KafkaConfig, KafkaServer}
 import org.apache.curator.test.TestingServer
-import org.jboss.netty.buffer.ChannelBuffers
+import io.netty.buffer.Unpooled
 import org.I0Itec.zkclient.ZkClient
 
 import okapies.finagle.Kafka
@@ -22,8 +22,8 @@ import okapies.finagle.kafka.protocol.{KafkaError, Message}
 object ClientTestUtils {
   val UTF_8 = Charset.forName("UTF-8")
 
-  implicit class CBString(s:String) {
-    def cb = ChannelBuffers.copiedBuffer(s, UTF_8)
+  implicit class ByteBufString(s:String) {
+    def byteBuf = Unpooled.copiedBuffer(s, UTF_8)
   }
 }
 
@@ -75,7 +75,7 @@ with KafkaTest {
   var client:Client = _
   val topic = "finagle.kafka.test.topic"
   val group = "test-group"
-  val msg = Message.create("hello".cb)
+  val msg = Message.create("hello".byteBuf)
 
   override implicit val patienceConfig =
     PatienceConfig(timeout = scaled(Span(5, Seconds)), interval = scaled(Span(500, Millis)))

--- a/src/test/scala/okapies/finagle/kafka/ServerTest.scala
+++ b/src/test/scala/okapies/finagle/kafka/ServerTest.scala
@@ -2,7 +2,7 @@ package okapies.finagle.kafka
 
 import org.scalatest._
 import org.scalatest.matchers._
-import org.jboss.netty.buffer.{ChannelBuffer, ChannelBuffers}
+import io.netty.buffer.Unpooled
 import com.twitter.concurrent.AsyncQueue
 import com.twitter.util.{Future, Await}
 import com.twitter.finagle.{Service, ListeningServer}
@@ -50,7 +50,7 @@ with BeforeAndAfterEach {
 
   val ClientId = "test-client"
   val Topic = "test-topic"
-  val Msg = Message.create(ChannelBuffers.EMPTY_BUFFER)
+  val Msg = Message.create(Unpooled.EMPTY_BUFFER)
   val ConsumerGroup = "test-group"
 
   val broker = Broker(0, "test", 9092)

--- a/src/test/scala/okapies/finagle/kafka/protocol/MessageSetTest.scala
+++ b/src/test/scala/okapies/finagle/kafka/protocol/MessageSetTest.scala
@@ -7,7 +7,7 @@ import org.scalatest.matchers._
 import java.nio.ByteBuffer
 import java.util.concurrent.atomic.AtomicLong
 
-import org.jboss.netty.buffer.ChannelBuffers
+import io.netty.buffer.Unpooled
 
 class MessageSetTest extends FlatSpec with Matchers {
 
@@ -24,17 +24,17 @@ class MessageSetTest extends FlatSpec with Matchers {
   it should "encode a MessageSet to bytes" in {
     val msgs1 = Seq[Message](
       Message.create(
-        ChannelBuffers.wrappedBuffer("value1".getBytes(utf8)),
-        Some(ChannelBuffers.wrappedBuffer("key1".getBytes(utf8))),
+        Unpooled.wrappedBuffer("value1".getBytes(utf8)),
+        Some(Unpooled.wrappedBuffer("key1".getBytes(utf8))),
         0
       ),
       Message.create(
-        ChannelBuffers.wrappedBuffer("value2".getBytes(utf8)),
-        Some(ChannelBuffers.wrappedBuffer("key2".getBytes(utf8))),
+        Unpooled.wrappedBuffer("value2".getBytes(utf8)),
+        Some(Unpooled.wrappedBuffer("key2".getBytes(utf8))),
         0
       )
     )
-    val buf1 = ChannelBuffers.dynamicBuffer()
+    val buf1 = Unpooled.buffer()
     var i: Long = 1
     buf1.encodeMessageSet(msgs1) { message =>
       buf1.encodeInt64(i) // offset
@@ -44,7 +44,7 @@ class MessageSetTest extends FlatSpec with Matchers {
 
     val size1 = buf1.readableBytes
     val kafkaMsgs1 =
-      new ByteBufferMessageSet(buf1.toByteBuffer(4, size1 - 4)) // skip MessageSetSize
+      new ByteBufferMessageSet(buf1.nioBuffer(4, size1 - 4)) // skip MessageSetSize
     val it1 = kafkaMsgs1.iterator
 
     val msg1 = it1.next()
@@ -75,7 +75,7 @@ class MessageSetTest extends FlatSpec with Matchers {
     buf1.put(kafkaMsgs1.buffer)
     buf1.rewind()
 
-    val chBuf1 = ChannelBuffers.wrappedBuffer(buf1)
+    val chBuf1 = Unpooled.wrappedBuffer(buf1)
     val msgs1 = chBuf1.decodeMessageSet()
     assert(chBuf1.readableBytes === 0)
 
@@ -103,7 +103,7 @@ class MessageSetTest extends FlatSpec with Matchers {
     buf1.put(kafkaMsgs1.buffer.array, 0, size1)
     buf1.rewind()
 
-    val chBuf1 = ChannelBuffers.wrappedBuffer(buf1)
+    val chBuf1 = Unpooled.wrappedBuffer(buf1)
     val msgs1 = chBuf1.decodeMessageSet()
     assert(chBuf1.readableBytes === 0)
 

--- a/src/test/scala/okapies/finagle/kafka/protocol/MessageTest.scala
+++ b/src/test/scala/okapies/finagle/kafka/protocol/MessageTest.scala
@@ -4,7 +4,7 @@ package protocol
 import org.scalatest._
 import org.scalatest.matchers._
 
-import org.jboss.netty.buffer.ChannelBuffers
+import io.netty.buffer.Unpooled
 
 class MessageTest extends FlatSpec with Matchers {
 
@@ -18,11 +18,11 @@ class MessageTest extends FlatSpec with Matchers {
 
   it should "encode a no compressed message" in {
     val msg1 = Message.create(
-      ChannelBuffers.wrappedBuffer("value1".getBytes(utf8)),     // value
-      Some(ChannelBuffers.wrappedBuffer("key1".getBytes(utf8))), // key
+      Unpooled.wrappedBuffer("value1".getBytes(utf8)),     // value
+      Some(Unpooled.wrappedBuffer("key1".getBytes(utf8))), // key
       0                                                          // codec
     )
-    val kafkaMsg1 = new KafkaMessage(msg1.underlying.toByteBuffer)
+    val kafkaMsg1 = new KafkaMessage(msg1.underlying.nioBuffer)
 
     assert(kafkaMsg1.checksum === msg1.crc)
     assert(kafkaMsg1.magic === msg1.magicByte)
@@ -31,11 +31,11 @@ class MessageTest extends FlatSpec with Matchers {
     assert(kafkaMsg1.payload.asString === "value1")
 
     val msg2 = Message.create(
-      ChannelBuffers.wrappedBuffer("value2".getBytes(utf8)),     // value
+      Unpooled.wrappedBuffer("value2".getBytes(utf8)),     // value
       None,                                                      // key
       0                                                          // codec
     )
-    val kafkaMsg2 = new KafkaMessage(msg2.underlying.toByteBuffer)
+    val kafkaMsg2 = new KafkaMessage(msg2.underlying.nioBuffer)
 
     assert(kafkaMsg2.checksum === msg2.crc)
     assert(kafkaMsg2.magic === msg2.magicByte)
@@ -50,7 +50,7 @@ class MessageTest extends FlatSpec with Matchers {
       "key1".getBytes(utf8),   // key
       NoCompressionCodec       // codec
     )
-    val msg1 = Message(ChannelBuffers.wrappedBuffer(kafkaMsg1.buffer))
+    val msg1 = Message(Unpooled.wrappedBuffer(kafkaMsg1.buffer))
 
     assert(msg1.crc === kafkaMsg1.checksum)
     assert(msg1.magicByte === kafkaMsg1.magic)
@@ -62,7 +62,7 @@ class MessageTest extends FlatSpec with Matchers {
       "value2".getBytes(utf8), // value
       NoCompressionCodec       // codec
     )
-    val msg2 = Message(ChannelBuffers.wrappedBuffer(kafkaMsg2.buffer))
+    val msg2 = Message(Unpooled.wrappedBuffer(kafkaMsg2.buffer))
 
     assert(msg2.crc === kafkaMsg2.checksum)
     assert(msg2.magicByte === kafkaMsg2.magic)

--- a/src/test/scala/okapies/finagle/kafka/protocol/StreamFrameDecoderTest.scala
+++ b/src/test/scala/okapies/finagle/kafka/protocol/StreamFrameDecoderTest.scala
@@ -5,8 +5,8 @@ import java.nio.ByteBuffer
 
 import scala.collection.immutable.ListMap
 
-import org.jboss.netty.buffer.{ChannelBuffer, ChannelBuffers}
-import org.jboss.netty.handler.codec.embedder.DecoderEmbedder
+import io.netty.buffer.{ByteBuf, Unpooled}
+import io.netty.channel.embedded.EmbeddedChannel
 
 import okapies.finagle.kafka.util.GatheringByteChannelMock
 
@@ -30,16 +30,16 @@ class StreamFrameDecoderTest extends FlatSpec with Matchers {
   behavior of "A StreamFrameDecoder"
 
   it should "decode the received ProduceResponse into a ResponseFrame" in {
-    val embedder = new DecoderEmbedder[ResponseFrame](
+    val channel = new EmbeddedChannel(
       new StreamFrameDecoder(RequestCorrelator(_ => Some(ApiKeyProduce)), 1024)
     )
     val headerLength = 4 /* Size */ + 4 /* CorrelationId */
 
     // do multiple times to detect state init failure
     for (i <- 0 to 1) {
-      val buf1 = createProduceResponseAsChannelBuffer(i)
-      embedder.offer(buf1.duplicate())
-      val BufferResponseFrame(apiKey1, correlationId1, frame1) = embedder.poll()
+      val buf1 = createProduceResponseAsByteBuf(i)
+      channel.writeInbound(Unpooled.copiedBuffer(buf1))
+      val BufferResponseFrame(apiKey1, correlationId1, frame1) = channel.readInbound[BufferResponseFrame]()
 
       assert(apiKey1 === ApiKeyProduce)
 
@@ -50,81 +50,82 @@ class StreamFrameDecoderTest extends FlatSpec with Matchers {
   }
 
   it should "decode the received FetchResponse into a ResponseFrame" in {
-    val embedder = new DecoderEmbedder[ResponseFrame](
+    val channel = new EmbeddedChannel(
       new StreamFrameDecoder(RequestCorrelator(_ => Some(ApiKeyFetch)), 1024)
     )
 
     // do multiple times to detect state init failure
     for (i <- 0 to 1) {
-      val buf1 = createFetchResponseAsChannelBuffer(i)
-      embedder.offer(buf1.duplicate())
-      val FetchResponseFrame(correlationId1) = embedder.poll()
+      val buf1 = createFetchResponseAsByteBuf(i)
+      channel.writeInbound(buf1.duplicate())
+      val FetchResponseFrame(correlationId1) = channel.readInbound[FetchResponseFrame]()
 
       assert(correlationId1 === i)
 
       // 1st partition in the response
-      val PartitionStatus(topicName1, partition1, error1, highwaterMarkOffset1) = embedder.poll()
+      val PartitionStatus(topicName1, partition1, error1, highwaterMarkOffset1) = channel.readInbound[PartitionStatus]
       assert(topicName1 === "test-topic2")
       assert(partition1 === 3 + i)
       assert(error1.code === 2)
       assert(highwaterMarkOffset1 === 2 + i)
 
       // 1st message in the response
-      val FetchedMessage(topicName11, partition11, offset11, msg11) = embedder.poll()
+      val FetchedMessage(topicName11, partition11, offset11, msg11) = channel.readInbound[FetchedMessage]()
       assert(topicName11 === "test-topic2")
       assert(partition11 === 3 + i)
       assert(offset11 === 0)
       assert(new String(getMessageValue(msg11), utf8) === "hello")
 
       // 2nd message in the response
-      val FetchedMessage(topicName12, partition12, offset12, msg12) = embedder.poll()
+      val FetchedMessage(topicName12, partition12, offset12, msg12) = channel.readInbound[FetchedMessage]()
       assert(topicName12 === "test-topic2")
       assert(partition12 === 3 + i)
       assert(offset12 === 1)
       assert(new String(getMessageValue(msg12), utf8) === "world")
 
       // 2nd partition in the response
-      val PartitionStatus(topicName2, partition2, error2, highwaterMarkOffset2) = embedder.poll()
+      val PartitionStatus(topicName2, partition2, error2, highwaterMarkOffset2) = channel.readInbound[PartitionStatus]()
       assert(topicName2 === "test-topic1")
       assert(partition2 === 1 + i)
       assert(error2.code === 1)
       assert(highwaterMarkOffset2 === 1 + i)
 
       // 3rd message in the response
-      val FetchedMessage(topicName21, partition21, offset21, msg21) = embedder.poll()
+      val FetchedMessage(topicName21, partition21, offset21, msg21) = channel.readInbound[FetchedMessage]()
       assert(topicName21 === "test-topic1")
       assert(partition21 === 1 + i)
       assert(offset21 === 0)
       assert(new String(getMessageValue(msg21), utf8) === "welcome")
 
       // 3rd partition in the response
-      val PartitionStatus(topicName3, partition3, error3, highwaterMarkOffset3) = embedder.poll()
+      val PartitionStatus(topicName3, partition3, error3, highwaterMarkOffset3) = channel.readInbound[PartitionStatus]()
       assert(topicName3 === "test-topic1")
       assert(partition3 === 2 + i)
       assert(error3.code === 1)
       assert(highwaterMarkOffset3 === 1 + i)
 
       // 4th message in the response
-      val FetchedMessage(topicName31, partition31, offset31, msg31) = embedder.poll()
+      val FetchedMessage(topicName31, partition31, offset31, msg31) = channel.readInbound[FetchedMessage]()
       assert(topicName31 === "test-topic1")
       assert(partition31 === 2 + i)
       assert(offset31 === 0)
       assert(new String(getMessageValue(msg31), utf8) === "welcome")
 
-      val msg6 = embedder.poll()
+
+      val msg6 = channel.readInbound[ResponseFrame]()
       assert(msg6 === NilMessageFrame)
     }
   }
 
   private[this] def getMessageValue(msg: Message): Array[Byte] = {
-    val payload = new KafkaMessage(msg.underlying.toByteBuffer).payload
+    val payload = new KafkaMessage(msg.underlying.nioBuffer).payload
     val value = new Array[Byte](payload.limit)
     payload.get(value)
 
     value
   }
 
-  private[this] def createProduceResponseAsChannelBuffer(i: Int) = {
+  private[this] def createProduceResponseAsByteBuf(i: Int) = {
     val status1 = KafkaProducerResponseStatus(1, 1 + i)
     val status2 = KafkaProducerResponseStatus(2, 2 + i)
     val res = KafkaProducerResponse(
@@ -139,10 +140,10 @@ class StreamFrameDecoderTest extends FlatSpec with Matchers {
     res.writeTo(buf)
     buf.rewind()
 
-    ChannelBuffers.wrappedBuffer(buf)
+    Unpooled.wrappedBuffer(buf)
   }
 
-  private[this] def createFetchResponseAsChannelBuffer(i: Int) = {
+  private[this] def createFetchResponseAsByteBuf(i: Int) = {
     val data1 = KafkaFetchResponsePartitionData(1, 1 + i, new ByteBufferMessageSet(
       new KafkaMessage("welcome".getBytes(utf8))
     ))
@@ -161,7 +162,7 @@ class StreamFrameDecoderTest extends FlatSpec with Matchers {
     new KafkaFetchResponseSend(res).writeTo(new GatheringByteChannelMock(buf))
     buf.rewind()
 
-    ChannelBuffers.wrappedBuffer(buf)
+    Unpooled.wrappedBuffer(buf)
   }
 
 }


### PR DESCRIPTION
Netty4 has been available in Finagle for some time and this PR migrates to use finagle-netty4 instead of finagle-netty3. It also updates to use Finagle 19.3.0. The most significant changes is from ChannelBuffer to ByteBuf and to use the Channel design in Netty 4.

While doing the migration I noticed that we use the raw finagle transport. As a future improvement we could instead use an implementation entirely with dispatchers as done in e.g. finagle-mux. See comment here https://github.com/twitter/finagle/blob/fe669e56f7a5b271b3e349748aaf4116dcf2bef6/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/Netty4Transporter.scala#L105

Made this into a draft pull request since I disabled the tracing and logging filters.